### PR TITLE
refactor(zerodha): simplify master contract download and remove legac…

### DIFF
--- a/india_stocks_api/internal/zerodha/database/__init__.py
+++ b/india_stocks_api/internal/zerodha/database/__init__.py
@@ -1,0 +1,5 @@
+"""Angel One Database Module"""
+
+from .master_contract_db import master_contract_download
+
+__all__ = ['master_contract_download']

--- a/india_stocks_api/internal/zerodha/database/master_contract_db.py
+++ b/india_stocks_api/internal/zerodha/database/master_contract_db.py
@@ -2,82 +2,12 @@
 
 import os
 import pandas as pd
-import numpy as np
-import gzip
-import shutil
-import json
 import io
-from utils.httpx_client import get_httpx_client
+from india_stocks_api.internal.context import get_httpx_client, get_logger
 
-
-from sqlalchemy import create_engine, Column, Integer, String, Float , Sequence, Index
-from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
-from database.auth_db import get_auth_token
-from extensions import socketio  # Import SocketIO
-from utils.logging import get_logger
+from india_stocks_api.internal.context import get_auth_token
 
 logger = get_logger(__name__)
-
-
-
-
-DATABASE_URL = os.getenv('DATABASE_URL')  # Replace with your database path
-
-engine = create_engine(DATABASE_URL)
-db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
-Base = declarative_base()
-Base.query = db_session.query_property()
-
-class SymToken(Base):
-    __tablename__ = 'symtoken'
-    id = Column(Integer, Sequence('symtoken_id_seq'), primary_key=True)
-    symbol = Column(String, nullable=False, index=True)  # Single column index
-    brsymbol = Column(String, nullable=False, index=True)  # Single column index
-    name = Column(String)
-    exchange = Column(String, index=True)  # Include this column in a composite index
-    brexchange = Column(String, index=True)  
-    token = Column(String, index=True)  # Indexed for performance
-    expiry = Column(String)
-    strike = Column(Float)
-    lotsize = Column(Integer)
-    instrumenttype = Column(String)
-    tick_size = Column(Float)
-
-    # Define a composite index on symbol and exchange columns
-    __table_args__ = (Index('idx_symbol_exchange', 'symbol', 'exchange'),)
-
-def init_db():
-    logger.info("Initializing Master Contract DB")
-    Base.metadata.create_all(bind=engine)
-
-def delete_symtoken_table():
-    logger.info("Deleting Symtoken Table")
-    SymToken.query.delete()
-    db_session.commit()
-
-def copy_from_dataframe(df):
-    logger.info("Performing Bulk Insert")
-    # Convert DataFrame to a list of dictionaries
-    data_dict = df.to_dict(orient='records')
-
-    # Retrieve existing tokens to filter them out from the insert
-    existing_tokens = {result.token for result in db_session.query(SymToken.token).all()}
-
-    # Filter out data_dict entries with tokens that already exist
-    filtered_data_dict = [row for row in data_dict if row['token'] not in existing_tokens]
-
-    # Insert in bulk the filtered records
-    try:
-        if filtered_data_dict:  # Proceed only if there's anything to insert
-            db_session.bulk_insert_mappings(SymToken, filtered_data_dict)
-            db_session.commit()
-            logger.info(f"Bulk insert completed successfully with {len(filtered_data_dict)} new records.")
-        else:
-            logger.info("No new records to insert.")
-    except Exception as e:
-        logger.error(f"Error during bulk insert: {e}")
-        db_session.rollback()
 
 
 def download_csv_zerodha_data(output_path):
@@ -92,8 +22,7 @@ def download_csv_zerodha_data(output_path):
         pd.DataFrame: DataFrame containing the downloaded instrument data
     """
     try:
-        login_username = os.getenv('LOGIN_USERNAME')
-        AUTH_TOKEN = get_auth_token(login_username)
+        AUTH_TOKEN = get_auth_token()
         
         # Get the shared httpx client with connection pooling
         client = get_httpx_client()
@@ -249,7 +178,7 @@ def delete_zerodha_temp_data(output_path):
         logger.error(f"An error occurred while deleting the file: {e}")
 
 
-def master_contract_download():
+def master_contract_download(db_path='instruments.db'):
     logger.info("Downloading Master Contract")
     
 
@@ -262,16 +191,19 @@ def master_contract_download():
         
         #token_df = token_df.drop_duplicates(subset='symbol', keep='first')
 
-        delete_symtoken_table()  # Consider the implications of this action
-        copy_from_dataframe(token_df)
-                
-        return socketio.emit('master_contract_download', {'status': 'success', 'message': 'Successfully Downloaded'})
+        # Convert DataFrame to list of dicts for our DB
+        records = token_df.to_dict('records')
+        
+        # Import here to avoid circular dependency
+        from ....instruments.database import InstrumentDB
+        
+        db = InstrumentDB(db_path)
+        db.raw_bulk_insert(records, truncate=True)
+        
+        logger.info(f"Successfully inserted {len(records)} instruments into database")
+        return len(records)
 
     
     except Exception as e:
-        logger.info(f"{str(e)}")
-        return socketio.emit('master_contract_download', {'status': 'error', 'message': str(e)})
-
-
-def search_symbols(symbol, exchange):
-    return SymToken.query.filter(SymToken.symbol.like(f'%{symbol}%'), SymToken.exchange == exchange).all()
+        logger.error(f"Master contract download failed: {e}")
+        raise


### PR DESCRIPTION
…y DB/socket code

- remove SQLAlchemy SymToken model and related session logic
- drop SocketIO emits and side effects
- centralize auth/http client via shared context
- switch to InstrumentDB.raw_bulk_insert for faster ingestion
- clean unused imports and legacy utilities
- simplify function to return inserted record count