### PR TITLE
refactor: move instruments.db into _cache/ for deterministic path res…

### DIFF
--- a/india_stocks_api/brokers/angel.py
+++ b/india_stocks_api/brokers/angel.py
@@ -50,10 +50,10 @@ class AngelOne(BaseBroker, broker_name="angel"):
         self.password = password
         self.totp_key = totp_key
 
-    def _download_master_contract(self, db_path: str = 'instruments.db'):
+    def _download_master_contract(self):
         """Download and populate Angel One master contract."""
         from ..internal.angel.database import master_contract_download
-        master_contract_download(db_path)
+        master_contract_download()
 
     def authenticate(self) -> bool:
         """

--- a/india_stocks_api/brokers/base.py
+++ b/india_stocks_api/brokers/base.py
@@ -1,7 +1,6 @@
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Optional, Dict, Type
 from functools import singledispatchmethod
-import os
 from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
@@ -53,50 +52,37 @@ class BaseBroker(ABC, metaclass=BrokerMeta):
             raise ValueError(f"Unknown broker: {broker_name}. Available: {list(cls._registry.keys())}")
         return cls._registry[broker_name](**kwargs)
     
-    def _ensure_instruments_ready(self, db_path: str = 'instruments.db'):
+    def _ensure_instruments_ready(self):
         """
         Check if instruments DB is stale and rebuild if needed.
         Called automatically by BrokerMeta after __init__.
-        
-        Args:
-            db_path: Path to the instruments database
         """
+        db_path = context.get_instruments_db_path()
         if self._is_db_stale(db_path):
-            from ..internal import context
             logger = context.get_logger(__name__)
-            logger.info(f"Instruments DB is stale or missing. Downloading master contract...")
-            self._download_master_contract(db_path)
+            logger.info("Instruments DB is stale or missing. Downloading master contract...")
+            self._download_master_contract()
             logger.info("Instruments DB ready.")
-    
-    def _is_db_stale(self, db_path: str) -> bool:
+
+    @staticmethod
+    def _is_db_stale(db_path) -> bool:
         """
         Returns True if DB doesn't exist or was last modified before today.
-        
-        Args:
-            db_path: Path to the instruments database
-            
-        Returns:
-            bool: True if DB needs refresh
         """
-        if not os.path.exists(db_path):
+        if not db_path.exists():
             return True
-        
-        # Check if file was modified today
-        mtime = os.path.getmtime(db_path)
+        mtime = db_path.stat().st_mtime
         file_date = datetime.fromtimestamp(mtime).date()
         return file_date < date.today()
-    
+
     @abstractmethod
-    def _download_master_contract(self, db_path: str = 'instruments.db'):
+    def _download_master_contract(self):
         """
         Subclasses must implement this to call their broker-specific download.
-        
+
         Example for AngelOne:
             from ..internal.angel.database import master_contract_download
-            master_contract_download(db_path)
-        
-        Args:
-            db_path: Path to the instruments database
+            master_contract_download()
         """
         ...
 

--- a/india_stocks_api/instruments/database.py
+++ b/india_stocks_api/instruments/database.py
@@ -41,9 +41,6 @@ class InstrumentDB:
     def __init__(self, db_path="instruments.db"):
         import os
         db_path = os.path.abspath(db_path)
-        print(f"DEBUG: InstrumentDB initializing at {db_path}")
-        print(f"DEBUG: Metadata Tables: {Base.metadata.tables.keys()}")
-        
         self.engine = create_engine(f"sqlite:///{db_path}")
         self.Session = sessionmaker(bind=self.engine)
         Base.metadata.create_all(self.engine)
@@ -134,7 +131,6 @@ class InstrumentDB:
             conn.commit()
             
         except Exception as e:
-            print(f"DEBUG: Raw Insert Error: {e}")
             raise
         finally:
             conn.close()

--- a/india_stocks_api/internal/angel/database/master_contract_db.py
+++ b/india_stocks_api/internal/angel/database/master_contract_db.py
@@ -7,7 +7,7 @@ import os
 import pandas as pd
 import requests
 from datetime import datetime
-from india_stocks_api.internal.context import get_logger
+from india_stocks_api.internal.context import get_logger, get_instruments_db_path, _CACHE_DIR
 
 logger = get_logger(__name__)
 
@@ -171,20 +171,18 @@ def delete_temp_file(output_path):
         logger.error(f"Error deleting temporary file: {e}")
 
 
-def master_contract_download(db_path='instruments.db'):
+def master_contract_download():
     """
     Main entry point: Downloads Angel One master contract and populates DB.
-    
-    Args:
-        db_path: Path to the instruments database
-        
+
     Returns:
         int: Number of instruments inserted
     """
     logger.info("Starting Angel One master contract download...")
-    
+
+    db_path = str(get_instruments_db_path())
     url = 'https://margincalculator.angelbroking.com/OpenAPI_File/files/OpenAPIScripMaster.json'
-    output_path = 'tmp/angel.json'
+    output_path = str(_CACHE_DIR / "tmp" / "angel.json")
     
     try:
         # Download raw JSON

--- a/india_stocks_api/internal/context.py
+++ b/india_stocks_api/internal/context.py
@@ -28,7 +28,8 @@ _HTTP_CLIENT: Optional[httpx.Client] = None
 
 _SESSION_CACHE: Dict[str, Dict[str, Any]] = {}
 _SESSION_LOADED: bool = False
-_SESSION_FILE = Path(__file__).parent.parent.parent / "_cache" / "sessions.json"
+_CACHE_DIR = Path(__file__).parent.parent.parent / "_cache"
+_SESSION_FILE = _CACHE_DIR / "sessions.json"
 
 
 def _get_session_path() -> Path:
@@ -159,13 +160,16 @@ from india_stocks_api.instruments.database import InstrumentDB
 
 _INSTRUMENT_DB = None
 
+
+def get_instruments_db_path() -> Path:
+    """Return the canonical path to instruments.db inside _cache/."""
+    return _CACHE_DIR / "instruments.db"
+
+
 def _get_db():
     global _INSTRUMENT_DB
     if _INSTRUMENT_DB is None:
-        chk_path = Path("instruments.db")
-        if not chk_path.exists():
-            chk_path = Path(__file__).parent.parent.parent / "instruments.db"
-        _INSTRUMENT_DB = InstrumentDB(str(chk_path))
+        _INSTRUMENT_DB = InstrumentDB(str(get_instruments_db_path()))
     return _INSTRUMENT_DB
 
 def get_br_symbol(symbol: str, exchange: str) -> str:

--- a/tests/unit/test_instruments_path.py
+++ b/tests/unit/test_instruments_path.py
@@ -1,0 +1,29 @@
+"""Tests for deterministic instruments.db path resolution."""
+from pathlib import Path
+
+from india_stocks_api.internal.context import (
+    _CACHE_DIR,
+    _SESSION_FILE,
+    get_instruments_db_path,
+)
+
+
+class TestInstrumentsPath:
+    def test_returns_path_under_cache(self):
+        path = get_instruments_db_path()
+        assert path.parent.name == "_cache"
+        assert path.name == "instruments.db"
+
+    def test_path_is_absolute(self):
+        assert get_instruments_db_path().is_absolute()
+
+    def test_cache_dir_matches_session_file_parent(self):
+        assert _CACHE_DIR == _SESSION_FILE.parent
+
+    def test_cache_dir_is_absolute(self):
+        assert _CACHE_DIR.is_absolute()
+
+    def test_cache_dir_resolves_to_project_root(self):
+        # _cache/ should be a sibling of the india_stocks_api package
+        package_dir = _CACHE_DIR.parent / "india_stocks_api"
+        assert package_dir.is_dir()


### PR DESCRIPTION
Replace fragile CWD heuristic with __file__-relative _CACHE_DIR constant. All runtime artifacts (sessions.json, instruments.db, tmp/) now live under _cache/, making the library work correctly regardless of working directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal database path handling by centralizing path resolution logic, removing redundant parameters from core functions.
  * Removed debug logging statements from initialization processes.
  * Refactored database staleness checks to use modernized path utilities.

* **Tests**
  * Added unit tests to verify deterministic path resolution for database files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->